### PR TITLE
Add LOOPBACK_HOST_URL Environment Variable

### DIFF
--- a/src/speaches/config.py
+++ b/src/speaches/config.py
@@ -253,3 +253,9 @@ class Config(BaseSettings):
 
     transcription_base_url: str | None = None
     transcription_api_key: str | None = None
+
+    loopback_host_url: str | None = None
+    """
+    If set this is the URL that the gradio app will use to connect to the API server hosting speaches.
+    If not set the gradio app will use the url that the user connects to the gradio app on.
+    """

--- a/src/speaches/gradio_app.py
+++ b/src/speaches/gradio_app.py
@@ -25,14 +25,16 @@ DEFAULT_TEXT = "A rainbow is an optical phenomenon caused by refraction, interna
 # NOTE: `gr.Request` seems to be passed in as the last positional (not keyword) argument
 
 
-def base_url_from_gradio_req(request: gr.Request) -> str:
+def base_url_from_gradio_req(request: gr.Request, config: Config) -> str:
+    if config.loopback_host_url is not None and len(config.loopback_host_url) > 0:
+        return config.loopback_host_url
     # NOTE: `request.request.url` seems to always have a path of "/gradio_api/queue/join"
     assert request.request is not None
     return f"{request.request.url.scheme}://{request.request.url.netloc}"
 
 
 def http_client_from_gradio_req(request: gr.Request, config: Config) -> httpx.AsyncClient:
-    base_url = base_url_from_gradio_req(request)
+    base_url = base_url_from_gradio_req(request, config)
     return httpx.AsyncClient(
         base_url=base_url,
         timeout=TIMEOUT,


### PR DESCRIPTION
Problem is described in #249 .  
We would like to be able to explicitly set the api server loopback url for cases where hosting is happening with different DNS from where the user is accessing the gradio app.

Let me know if there are other things required like updates to documentation for this change, or if you think it is not in the correct direction for the project.
