### PR TITLE
Fix: do not fail when hf cache location contains unparseable paths

### DIFF
--- a/src/speaches/hf_utils.py
+++ b/src/speaches/hf_utils.py
@@ -139,6 +139,8 @@ def get_model_path(model_id: str, *, cache_dir: str | Path | None = None) -> Pat
             continue
         if repo_path.name == ".locks":  # skip './.locks/' folder
             continue
+        if "--" not in repo_path.name:  # cache might contain unrelated custom files
+            continue
         repo_type, repo_id = repo_path.name.split("--", maxsplit=1)
         repo_type = repo_type[:-1]  # "models" -> "model"
         repo_id = repo_id.replace("--", "/")  # google--fleurs -> "google/fleurs"


### PR DESCRIPTION
Currently, `speaches` fails to load TTS models when HF cache contains custom files that do not follow the `--` schema, this small fix skips over such files altogether, similarly to `.locks`