### PR TITLE
Enables VAD filter by default

### DIFF
--- a/src/speaches/routers/stt.py
+++ b/src/speaches/routers/stt.py
@@ -240,7 +240,7 @@ def transcribe_file(
     ] = ["segment"],
     stream: Annotated[bool, Form()] = False,
     hotwords: Annotated[str | None, Form()] = None,
-    vad_filter: Annotated[bool, Form()] = False,
+    vad_filter: Annotated[bool, Form()] = True,
 ) -> Response | StreamingResponse:
     if model is None:
         model = config.whisper.model


### PR DESCRIPTION
Enables the VAD filter by default to prevent hallucinations on blank audio.