### PR TITLE
Use huggingface-cache if HF_HUB_OFFLINE is set

### DIFF
--- a/src/speaches/routers/models.py
+++ b/src/speaches/routers/models.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Annotated
 
 from fastapi import (
@@ -13,7 +14,7 @@ from speaches.api_types import (
     ListModelsResponse,
     Model,
 )
-from speaches.hf_utils import list_whisper_models
+from speaches.hf_utils import list_local_whisper_models, list_whisper_models
 
 if TYPE_CHECKING:
     from huggingface_hub.hf_api import ModelInfo
@@ -23,7 +24,10 @@ router = APIRouter(tags=["models"])
 
 @router.get("/v1/models")
 def get_models() -> ListModelsResponse:
-    whisper_models = list(list_whisper_models())
+    if os.getenv("HF_HUB_OFFLINE") is not None:
+        whisper_models = list(list_local_whisper_models())
+    else:
+        whisper_models = list(list_whisper_models())
     return ListModelsResponse(data=whisper_models)
 
 


### PR DESCRIPTION
This PR modifies the list_local_whisper_models to return the same structure as list_whisper_models to enable the possibility to use the huggingface cache if HF_HUB_OFFLINE is set. Also it modifies the get_models function to use the according function depending on HF_HUB_OFFLINE.
This PR also introduces a dropdown in the WebUI for selecting the output format (text,json, srt..) SRT seems not to work in streaming mode.
You need to be online once to download the README.md which is used to fill the metadata