### PR TITLE
expose vad_auto_close param on transcription streaming endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 ARG BASE_IMAGE=nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04
 # hadolint ignore=DL3006
 FROM ${BASE_IMAGE}
+
+# Install CA certificates
+RUN apt-get update && \
+    apt-get install -y ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
 LABEL org.opencontainers.image.source="https://github.com/speaches-ai/speaches"
 LABEL org.opencontainers.image.licenses="MIT"
 # `ffmpeg` is installed because without it `gradio` won't work with mp3(possible others as well) files

--- a/compose.cpu.yaml
+++ b/compose.cpu.yaml
@@ -5,10 +5,6 @@ services:
     extends:
       file: compose.yaml
       service: speaches
-    # Expose the container on host port 8001 (rather than 8000
-    # which is used by the official / default)
-    ports:
-      - "8001:8000"
     # Comment out the official image, use the local build instead
     # image: ghcr.io/speaches-ai/speaches:latest-cpu
     build:
@@ -19,6 +15,12 @@ services:
         - "cm-speaches-cpu:latest-v1"
     environment:
       - WHISPER__MODEL=Systran/faster-whisper-small
+      - MAX_NO_DATA_SECONDS=5.0  # default is 1.0
+      # # Configs for VAD
+      # - MAX_INACTIVITY_SECONDS=2.5
+      # - INACTIVITY_WINDOW_SECONDS=5.0
+      # - MIN_DURATION=1.0
+
     volumes:
       - hf-hub-cache:/home/ubuntu/.cache/huggingface/hub
 volumes:

--- a/compose.cpu.yaml
+++ b/compose.cpu.yaml
@@ -1,14 +1,22 @@
 # include:
 #   - compose.observability.yaml
 services:
-  speaches:
+  cm-speaches:
     extends:
       file: compose.yaml
       service: speaches
-    image: ghcr.io/speaches-ai/speaches:latest-cpu
+    # Expose the container on host port 8001 (rather than 8000
+    # which is used by the official / default)
+    ports:
+      - "8001:8000"
+    # Comment out the official image, use the local build instead
+    # image: ghcr.io/speaches-ai/speaches:latest-cpu
     build:
       args:
         BASE_IMAGE: ubuntu:24.04
+      tags:
+        - "cm-speaches-cpu:latest"
+        - "cm-speaches-cpu:latest-v1"
     environment:
       - WHISPER__MODEL=Systran/faster-whisper-small
     volumes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 # TODO: https://docs.astral.sh/uv/guides/integration/docker/#configuring-watch-with-docker-compose
 services:
   speaches:
-    container_name: speaches
+    container_name: cm-speaches
     build:
       dockerfile: Dockerfile
       context: .

--- a/relaunch-docker.sh
+++ b/relaunch-docker.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+export COMPOSE_FILE=compose.cpu.yaml
+docker compose down
+docker compose up -d --build


### PR DESCRIPTION
This PR exposes a new optional parameter `vad_auto_close` on the streaming endpoint:

* Previously, if VAD detects more than `max_inactivity_seconds` of inactivity, the websocket would be closed.  
* This default behavior is unchanged.
* However, calling `ws://localhost:8000/v1/audio/transcriptions?vad_auto_close=false` suppresses both the disconnect and the VAD call to determine if the inactivity threshold has been met.