### PR TITLE
Sync missing extra dependencies - opentelemetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --compile-bytecode --no-install-project
 COPY --chown=ubuntu ./src ./pyproject.toml ./uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --compile-bytecode --extra ui
+    uv sync --frozen --compile-bytecode --extra ui --extra opentelemetry
 # Creating a directory for the cache to avoid the following error:
 # PermissionError: [Errno 13] Permission denied: '/home/ubuntu/.cache/huggingface/hub'
 # This error occurs because the volume is mounted as root and the `ubuntu` user doesn't have permission to write to it. Pre-creating the directory solves this issue.


### PR DESCRIPTION
opentelemetry was missing in `uv sync` which failed to start the program when I build the Dockerfile and run it