### PR TITLE
Doc update: Corrected link to tts page in warning admonition

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 !!! warning
 
-    Additional steps are required to use the text-to-speech feature. Please see the [Text-to-Speech](/docs/usage/text-to-speech.md#prerequisite).
+    Additional steps are required to use the text-to-speech feature. Please see the [Text-to-Speech](/usage/text-to-speech/#Prerequisite).
 
 ## Docker Compose (Recommended)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 !!! warning
 
-    Additional steps are required to use the text-to-speech feature. Please see the [Text-to-Speech](/usage/text-to-speech/#Prerequisite).
+    Additional steps are required to use the text-to-speech feature. Please see the [Text-to-Speech](/usage/text-to-speech/#prerequisite).
 
 ## Docker Compose (Recommended)
 


### PR DESCRIPTION
Currently the installation page has an admonition about downloading TTS models that links to the wrong place and results in a 404. This is just a little one liner that corrects that link