### PR TITLE
Fix: Resolve Pydantic and parsing errors for Piper TTS models

### DIFF
--- a/src/speaches/executors/piper/model_manager.py
+++ b/src/speaches/executors/piper/model_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from pathlib import Path
 import json
 import logging
 import threading
@@ -35,7 +36,7 @@ class PiperModelManager:
         )  # HACK: `get_available_providers` is an unknown symbol (on MacOS at least)
         available_providers = available_providers - ORT_PROVIDERS_BLACKLIST
         inf_sess = InferenceSession(model_files.model, providers=list(available_providers))
-        conf = PiperConfig.from_dict(json.loads(model_files.config.read_text()))
+        conf = PiperConfig.from_dict(json.loads(Path(model_files.config).read_text()))
         return PiperVoice(session=inf_sess, config=conf)
 
     def _handle_model_unloaded(self, model_id: str) -> None:

--- a/src/speaches/executors/piper/utils.py
+++ b/src/speaches/executors/piper/utils.py
@@ -40,9 +40,10 @@ TAGS = {"speaches", "piper"}
 
 
 class PiperModelFiles(BaseModel):
-    model: Path
-    config: Path
+    model: str 
+    config: str 
 
+PiperModelFiles.model_rebuild()
 
 class PiperModelVoice(BaseModel):
     name: str
@@ -98,9 +99,9 @@ class PiperModelRegistry(ModelRegistry):
             if model_card_data is None:
                 continue
             if self.hf_model_filter.passes_filter(model_card_data):
-                repo_id_parts = cached_repo_info.repo_id.split("-")
-                assert len(repo_id_parts) == 3, cached_repo_info.repo_id
-                _language_and_region, name, quality = repo_id_parts
+                repo_id_parts = cached_repo_info.repo_id.split("/")[-1].split("-")
+                assert len(repo_id_parts) == 4, cached_repo_info.repo_id
+                _prefix, _language_and_region, name, quality = repo_id_parts
                 assert quality in PIPER_VOICE_QUALITY_SAMPLE_RATE_MAP, cached_repo_info.repo_id
                 sample_rate = PIPER_VOICE_QUALITY_SAMPLE_RATE_MAP[quality]
                 languages = extract_language_list(model_card_data)
@@ -127,8 +128,8 @@ class PiperModelRegistry(ModelRegistry):
         config_file_path = next(file_path for file_path in model_files if file_path.name == "config.json")
 
         return PiperModelFiles(
-            model=model_file_path,
-            config=config_file_path,
+            model=str(model_file_path),
+            config=str(config_file_path),
         )
 
     def download_model_files(self, model_id: str) -> None:


### PR DESCRIPTION
## Problem
This PR fixes two critical issues with Piper TTS models:
1. AssertionError in `piper/utils.py` when listing models
2. PydanticUserError (followed by AttributeError) when loading Piper models for synthesis

## Solution
- **Model ID parsing**: Adjusted to properly handle 4-part model IDs
- **PiperModelFiles**: Changed field types to `str` and added explicit `str()` conversions
- **Import fix**: Added missing `from pathlib import Path` for `read_text()` method

## Testing
- Verified Piper models list and load without errors via Gradio
- Tested `curl` commands on command line

Fixes #390