### PR TITLE
Fix/handle legacy library metadata

### DIFF
--- a/src/speaches/hf_utils.py
+++ b/src/speaches/hf_utils.py
@@ -26,8 +26,11 @@ class HfModelFilter(BaseModel):
     def passes_filter(self, model_card_data: huggingface_hub.ModelCardData) -> bool:
         # convert None to an empty set so it's easier to work with
         model_card_data_tags = set(model_card_data.tags) if model_card_data.tags is not None else set()
-        if self.library_name is not None and model_card_data.library_name != self.library_name:
-            return False
+        if self.library_name is not None:
+            # Handle both 'library_name' (correct) and 'library' (legacy/incorrect) fields
+            model_library = model_card_data.library_name or getattr(model_card_data, "library", None)
+            if model_library != self.library_name:
+                return False
         if self.task is not None and (
             self.task != model_card_data.pipeline_tag and self.task not in model_card_data_tags
         ):


### PR DESCRIPTION
## Summary
Fixes compatibility issues with Hugging Face models that use the legacy `library` field instead of the standard `library_name` field in their README.md metadata.  

This PR seemed easier than getting metadats on all HF speaches-ai Piper models metadata.

## Problem
Some Piper TTS models use inconsistent metadata format in their model cards:

```yaml
# ❌ Legacy format (some models)
library: onnx

# ✅ Standard format (expected)
library_name: onnx
```

This causes models to:
- ✅ Download successfully (no metadata validation during download)
- ❌ Not appear in model listings (filtered out during `list_local_models()`)
- ❌ Return 404 errors when used via API (filtered out during model validation)

**Root Cause:** The `HfModelFilter.passes_filter()` method only checks `model_card_data.library_name`, but some models only populate the legacy `library` field.

## Solution
Enhanced metadata filtering logic to check both fields:
1. `library_name` (standard field)  
2. `library` (field as fallback)

This ensures compatibility without requiring immediate metadata fixes from model authors.

## Testing
- ✅ Models with `library_name` continue to work
- ✅ Models with only `library` now work correctly  
- ✅ Models appear in Gradio UI listings
- ✅ Models can be used via curl API

## Examples
Tested models from the speaches-ai organisation that use the `library_name` metadata:
- `speeches-ai/piper-en_GB-alan-low`

Tested models from the speeches-ai organization that use the `library` metadata:
- `speeches-ai/piper-en_US-amy-low`
- `speeches-ai/piper-en_GB-southern_english_female-low`
```