### PR TITLE
Add ca-certificates to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.licenses="MIT"
 # `ffmpeg` is installed because without it `gradio` won't work with mp3(possible others as well) files
 # hadolint ignore=DL3008
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl ffmpeg && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl ffmpeg && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 # "ubuntu" is the default user on ubuntu images with UID=1000. This user is used for two reasons:


### PR DESCRIPTION
The Dockerfile installs `curl` and if you were to run curl inside the container you would get an error:

```bash
curl: (77) error setting certificate file: /etc/ssl/certs/ca-certificates.crt
```

This happens because the CA certificates are not installed. If you are going to include curl in the Docker image, you should also include the certs to allow for TLS verification. In a lot of the issues opened on this repo, people are executing curl with the `-k` flag. That flag is short for `--insecure` which skips TLS verification. This is bad and should be avoided.

Simple solution is to install the `ca-certificates`.