### PR TITLE
Fix: Update Gradio version to resolve blank interface issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
     "httpx-sse>=0.4.1",
 ]
 ui = [
-    "gradio>=5.13.0",
+    "gradio>=5.49.0",
     "httpx-sse>=0.4.1",
 ]
 opentelemetry = [


### PR DESCRIPTION
**Summary**

This PR updates the Gradio dependency to the latest version to fix the blank interface issue described in [gradio-app/gradio#11553](https://github.com/gradio-app/gradio/issues/11553).

**Details**

* The blank UI issue appears to be related to **locale/regional settings** — it occurs under certain system language or locale configurations.
* The issue has been confirmed and fixed upstream in the latest Gradio release.
* After updating to the latest Gradio version, the `speaches` web interface now loads correctly.

**Verification**

* Tested with the following Docker images:

  * ✅ `ghcr.io/speaches-ai/speaches:0.9.0-rc.1-cuda` — UI loads correctly after fix
  * ❌ `ghcr.io/speaches-ai/speaches:latest-cuda-12.6.3` — still shows a blank page before fix

**Changes**

* Updated `gradio` dependency to the latest version.
* Rebuilt and verified the frontend loads properly.

**References**

* Related issue: [gradio-app/gradio#11553](https://github.com/gradio-app/gradio/issues/11553)