### PR TITLE
Changed temperature default value to None

### DIFF
--- a/src/speaches/routers/stt.py
+++ b/src/speaches/routers/stt.py
@@ -116,7 +116,7 @@ def translate_file(
     model: Annotated[ModelId, Form()],
     prompt: Annotated[str | None, Form()] = None,
     response_format: Annotated[ResponseFormat, Form()] = DEFAULT_RESPONSE_FORMAT,
-    temperature: Annotated[float, Form()] = 0.0,
+    temperature: Annotated[float | None, Form()] = None,
     stream: Annotated[bool, Form()] = False,
     vad_filter: Annotated[bool | None, Form()] = None,
 ) -> Response | StreamingResponse:
@@ -129,7 +129,7 @@ def translate_file(
             audio,
             task="translate",
             initial_prompt=prompt,
-            temperature=temperature,
+            temperature=temperature if temperature is not None else [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
             vad_filter=effective_vad_filter,
         )
         segments = TranscriptionSegment.from_faster_whisper_segments(segments)
@@ -168,7 +168,7 @@ def transcribe_file(  # noqa: C901
     language: Annotated[str | None, Form()] = None,
     prompt: Annotated[str | None, Form()] = None,
     response_format: Annotated[ResponseFormat, Form()] = DEFAULT_RESPONSE_FORMAT,
-    temperature: Annotated[float, Form()] = 0.0,
+    temperature: Annotated[float | None, Form()] = None,
     timestamp_granularities: Annotated[
         TimestampGranularities,
         # WARN: `alias` doesn't actually work.
@@ -210,7 +210,7 @@ def transcribe_file(  # noqa: C901
                 language=language,
                 initial_prompt=prompt,
                 word_timestamps="word" in timestamp_granularities,
-                temperature=temperature,
+                temperature=temperature if temperature is not None else [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
                 vad_filter=effective_vad_filter,
                 hotwords=hotwords,
                 without_timestamps=without_timestamps,


### PR DESCRIPTION
**Issue :**

Sometimes, the generated transcription gets stuck repeating the same words, and there is a warning :

Compression ratio threshold is not met with temperature 0.0

The problem is that the default value for temperature is 0 in speaches. The problem can be solved if we pass a higher temperature but it will apply to all the transcript.

The default behavior in faster-whisper is that if temperature is not specified, it is considered 0 and only when compression ratio threshold or log probability threshold are not met for a certain segment then it will try with temperature 0.2 and so on from the list [0, 0.2, 0.4, 0.6, 0.8, 1.0] for that segment.

**Fix :**

Change the default value for temperature to the same default list used in faster-whisper to let it handle retries for segments where compression ratio threshold or log probability threshold criterias are not met.
