### PR TITLE
fix: Chinese text incorrectly stripped by emoji filter

### DIFF
--- a/src/speaches/text_utils.py
+++ b/src/speaches/text_utils.py
@@ -148,7 +148,6 @@ def strip_emojis(text: str) -> str:
         "\U0001fa00-\U0001fa6f"  # Chess Symbols
         "\U0001fa70-\U0001faff"  # Symbols and Pictographs Extended-A
         "\U00002702-\U000027b0"  # Dingbats
-        "\U000024c2-\U0001f251"
         "]+",
         flags=re.UNICODE,
     )


### PR DESCRIPTION
## Problem

Chinese text (CJK characters) is being completely removed by the `strip_emojis()` function before TTS processing, resulting in empty audio output.

### Root Cause

The Unicode range `\U000024c2-\U0001f251` in the emoji pattern incorrectly includes Chinese characters (CJK Unified Ideographs), causing them to be stripped as if they were emojis.

### Impact

- Chinese TTS generates 0-byte audio files
- Mixed Chinese-English text only preserves English words
- Example: "你好" → "" (empty string) → no audio
- Example: "OpenClaw 是一个开源项目" → "OpenClaw  " → only "OpenClaw" is spoken

## Solution

Remove the problematic Unicode range `\U000024c2-\U0001f251` from the emoji pattern in `strip_emojis()`.

## Testing

### Before Fix
```python
strip_emojis("你好")  # Returns: "" (empty)
strip_emojis("Hello")  # Returns: "Hello"
```

### After Fix
```python
strip_emojis("你好")  # Returns: "你好" ✅
strip_emojis("Hello")  # Returns: "Hello" ✅
```

### TTS Test Results

| Input | Before | After |
|-------|--------|-------|
| "你好" | 0 KB (empty audio) | 32 KB ✅ |
| "你好，世界！" | 0 KB | 54 KB ✅ |
| "这是一个中文语音合成测试。" | 0 KB | 126 KB ✅ |
| "OpenClaw 是一个开源项目" | 41 KB (English only) | 215 KB ✅ |

All Chinese TTS tests now pass with proper audio generation.

## Files Changed

- `src/speaches/text_utils.py`: Remove problematic Unicode range from emoji pattern

## Related Issues

This fixes Chinese TTS functionality for Piper models (e.g., `speaches-ai/piper-zh_CN-huayan-medium`).

## Checklist

- [x] Tested with Chinese text
- [x] Tested with English text
- [x] Tested with mixed Chinese-English text
- [x] Verified emoji removal still works for actual emojis
- [x] No breaking changes to existing functionality