### PR TITLE
feat: Make Dockerfile compatible with OpenShift and non-root environments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,35 +9,21 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl ffmpeg && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-# "ubuntu" is the default user on ubuntu images with UID=1000. This user is used for two reasons:
-#   1. It's generally a good practice to run containers as non-root users. See https://www.docker.com/blog/understanding-the-docker-user-instruction/
-#   2. Docker Spaces on HuggingFace don't support running containers as root. See https://huggingface.co/docs/hub/en/spaces-sdks-docker#permissions
-# NOTE: the following command was added since nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04 doesn't have the `ubuntu` user
-RUN useradd --create-home --shell /bin/bash --uid 1000 ubuntu || true
-USER ubuntu
-ENV HOME=/home/ubuntu \
-    PATH=/home/ubuntu/.local/bin:$PATH
-WORKDIR $HOME/speaches
-# https://docs.astral.sh/uv/guides/integration/docker/#installing-uv
-COPY --chown=ubuntu --from=ghcr.io/astral-sh/uv:0.8.22 /uv /bin/uv
-# NOTE: per https://docs.astral.sh/uv/guides/install-python, `uv` will automatically install the necessary python version
-# https://docs.astral.sh/uv/guides/integration/docker/#intermediate-layers
-# https://docs.astral.sh/uv/guides/integration/docker/#compiling-bytecode
-# TODO: figure out if `/home/ubuntu/.cache/uv` should be used instead of `/root/.cache/uv`
-RUN --mount=type=cache,target=/root/.cache/uv \
-    --mount=type=bind,source=uv.lock,target=uv.lock \
-    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --compile-bytecode --no-install-project --no-dev
-COPY --chown=ubuntu . .
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --compile-bytecode --no-dev
-# Creating a directory for the cache to avoid the following error:
-# PermissionError: [Errno 13] Permission denied: '/home/ubuntu/.cache/huggingface/hub'
-# This error occurs because the volume is mounted as root and the `ubuntu` user doesn't have permission to write to it. Pre-creating the directory solves this issue.
-RUN mkdir -p $HOME/.cache/huggingface/hub
+# Workdir outside $HOME to avoid permission issues when running as non-root user
+WORKDIR /app
+COPY --from=ghcr.io/astral-sh/uv:0.8.22 /uv /bin/uv
+COPY . .
+# Specify the cache and install directories for `uv` to avoid permission issues when running as non-root user
+ENV UV_CACHE_DIR=/app/.uv-cache
+ENV UV_PYTHON_INSTALL_DIR=/app/.uv-python
+RUN uv sync --frozen --compile-bytecode --no-dev
+# Change the group ownership and permissions of the installed packages to allow access for non-root users
+RUN chgrp -R 0 /app/.venv/bin/ && \
+    chmod -R g=u  /app/.venv/bin/
+
 ENV UVICORN_HOST=0.0.0.0
 ENV UVICORN_PORT=8000
-ENV PATH="$HOME/speaches/.venv/bin:$PATH"
+ENV PATH="/app/.venv/bin:$PATH"
 # https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#hfhubenablehftransfer
 # NOTE: I've disabled this because it doesn't inside of Docker container. I couldn't pinpoint the exact reason. This doesn't happen when running the server locally.
 # RuntimeError: An error occurred while downloading using `hf_transfer`. Consider disabling HF_HUB_ENABLE_HF_TRANSFER for better error handling.


### PR DESCRIPTION
This pull request refactors the Dockerfile to ensure compatibility with security-constrained container platforms like OpenShift, which enforce a "run as non-root" policy with an arbitrary user ID.

The previous Dockerfile was not suitable for these environments because it relied on:
   1. The creation of a hardcoded ubuntu user (uid 1000).
   2. A WORKDIR located in the user's home directory (/home/ubuntu).

This approach fails when the container is launched with an arbitrary, non-root user, as that user lacks permissions to write to the home directory or other root-owned locations.

To address this, the Dockerfile has been modified as follows:

   - Removed User Creation: The USER instruction and useradd command have been removed. The container is now designed to be run by any user ID.
   - Standardized `WORKDIR`: The working directory is now set to a neutral /app location.
   - Permissions for Arbitrary Users: Added a RUN step using chgrp and chmod to adjust group ownership and permissions on the virtual environment's binaries (.venv/bin). This is the key
     change that allows an arbitrary user (belonging to the root group, GID 0) to execute the application.
   - Cleaned up Paths: All paths and environment variables (like PATH and uv cache directories) have been updated to use the /app directory, ensuring all application-related files are kept
     in one place.

  These changes make our container more secure and portable, enabling seamless deployment on OpenShift and other locked-down environments without sacrificing functionality.
