### PR TITLE
fix: use default whisper temperature values for temperature 0.0 like openai api

### DIFF
--- a/src/speaches/executors/shared/handler_protocol.py
+++ b/src/speaches/executors/shared/handler_protocol.py
@@ -62,7 +62,7 @@ class TranscriptionRequest(BaseModel):
     language: str | None = None
     prompt: str | None = None
     response_format: openai.types.AudioResponseFormat = "json"
-    temperature: float = 0.0
+    temperature: float | list[float] = 0.0
     hotwords: str | None = None
     timestamp_granularities: TimestampGranularities
     speech_segments: list[SpeechTimestamp]
@@ -103,7 +103,7 @@ class TranslationRequest(BaseModel):
     model: str
     prompt: str | None = None
     response_format: openai.types.AudioResponseFormat = "json"
-    temperature: float = 0.0
+    temperature: float | list[float] = 0.0
     speech_segments: list[SpeechTimestamp]
     vad_options: VadOptions
 

--- a/src/speaches/routers/stt.py
+++ b/src/speaches/routers/stt.py
@@ -66,7 +66,7 @@ def translate_file(
     model: Annotated[ModelId, Form()],
     prompt: Annotated[str | None, Form()] = None,
     response_format: Annotated[ResponseFormat, Form()] = DEFAULT_RESPONSE_FORMAT,
-    temperature: Annotated[float, Form()] = 0.0,
+    temperature: Annotated[float | list[float], Form()] = 0.0,
 ) -> Response:
     model_card_data = get_model_card_data_or_raise(model)
     executor = find_executor_for_model_or_raise(model, model_card_data, executor_registry.translation)
@@ -79,7 +79,7 @@ def translate_file(
         model=model,
         prompt=prompt,
         response_format=response_format,
-        temperature=temperature,
+        temperature=temperature if temperature != 0.0 else [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
         speech_segments=speech_segments,
         vad_options=DEFAULT_VAD_OPTIONS,
     )
@@ -129,7 +129,7 @@ def transcribe_file(
     language: Annotated[str | None, Form()] = None,
     prompt: Annotated[str | None, Form()] = None,
     response_format: Annotated[ResponseFormat, Form()] = DEFAULT_RESPONSE_FORMAT,
-    temperature: Annotated[float, Form()] = 0.0,
+    temperature: Annotated[float | list[float], Form()] = 0.0,
     timestamp_granularities: Annotated[
         TimestampGranularities,
         # WARN: `alias` doesn't actually work.
@@ -160,7 +160,7 @@ def transcribe_file(
         language=language,
         prompt=prompt,
         response_format=response_format,
-        temperature=temperature,
+        temperature=temperature if temperature != 0.0 else [0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
         timestamp_granularities=timestamp_granularities,
         stream=stream,
         hotwords=hotwords,


### PR DESCRIPTION
Hi,

It's an alternative version of #553 made for the latest v0.9.0 RC.

So, like the OpenAI API, the default temperature remains 0.0. But OpenAI made some temperature changes behind this, cf: https://developers.openai.com/api/reference/resources/audio/subresources/transcriptions/methods/create

> If set to 0, the model will use log probability (https://en.wikipedia.org/wiki/Log_probability) to automatically increase the temperature until certain thresholds are hit.

Then we can see that the default Whisper temperature values are a list of temperatures, cf: https://whisper-api.com/docs/transcription-options/#sampling-temperature

> The default temperature values are [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]

So, I think that OpenAI transforms the temperature 0.0 to [0.0, 0.2, 0.4, 0.6, 0.8, 1.0] to activate that "automatically increase the temperature until certain thresholds are hit" feature.

Here we are doing the same. So it will fix the bug in #553.

Regards,

Morgan
