### PR TITLE
fix: support newer onnx-asr Nemo import path

### DIFF
--- a/src/speaches/executors/parakeet.py
+++ b/src/speaches/executors/parakeet.py
@@ -6,7 +6,11 @@ from typing import TypedDict
 import huggingface_hub
 import onnx_asr
 from onnx_asr.adapters import TextResultsAsrAdapter
-from onnx_asr.models import NemoConformerTdt
+
+try:
+    from onnx_asr.models import NemoConformerTdt
+except ImportError:
+    from onnx_asr.models.nemo import NemoConformerTdt
 import openai.types.audio
 from opentelemetry import trace
 


### PR DESCRIPTION
## What was broken

`speaches` failed to start when `onnx-asr` 0.11+ was installed.

Startup crashed while importing the Parakeet executor with:

`ImportError: cannot import name 'NemoConformerTdt' from 'onnx_asr.models'`

The current code assumes `NemoConformerTdt` is available from:

`onnx_asr.models`

That is no longer true in newer `onnx-asr` releases, where the class is exposed from:

`onnx_asr.models.nemo`

## What this changes

This patch keeps the existing import for older versions and adds a fallback for newer ones.

- first try: `from onnx_asr.models import NemoConformerTdt`
- fallback to: `from onnx_asr.models.nemo import NemoConformerTdt`

## What this fixes

- restores app startup when newer `onnx-asr` versions are installed
- keeps compatibility with the older import path used by the current locked dependency set
- avoids forcing users to downgrade `onnx-asr` just to run the server

## Why this matters

This failure happens before the app is fully up, so users hit a hard startup error even if they are not actively using the Parakeet path.

The fallback keeps the change narrow and makes startup more tolerant of dependency drift.