### PR TITLE
Set batch_size=1 for BatchedInferencePipeline transcribe calls

### DIFF
--- a/src/speaches/executors/whisper.py
+++ b/src/speaches/executors/whisper.py
@@ -160,6 +160,7 @@ class WhisperModelManager(BaseModelManager[WhisperModel]):
             )
             segments, transcription_info = whisper_model.transcribe(
                 request.audio.data,
+                batch_size=1,
                 task="transcribe",
                 language=request.language,
                 initial_prompt=request.prompt,
@@ -199,6 +200,7 @@ class WhisperModelManager(BaseModelManager[WhisperModel]):
             )
             segments, _transcription_info = whisper_model.transcribe(
                 request.audio.data,
+                batch_size=1,
                 task="transcribe",
                 language=request.language,
                 initial_prompt=request.prompt,
@@ -245,6 +247,7 @@ class WhisperModelManager(BaseModelManager[WhisperModel]):
 
             segments, transcription_info = whisper_model.transcribe(
                 request.audio.data,
+                batch_size=1,
                 task="translate",
                 initial_prompt=request.prompt,
                 temperature=request.temperature,


### PR DESCRIPTION
Prevents OOM on VRAM-constrained GPUs (e.g., 8GB) when using large-v3.