### PR TITLE
fix model download examples

### DIFF
--- a/docs/usage/speech-to-text.md
+++ b/docs/usage/speech-to-text.md
@@ -15,13 +15,14 @@ TODO: add a note about vad
 export SPEACHES_BASE_URL="http://localhost:8000"
 
 # Listing all available STT models
-uvx speaches-cli registry ls --task automatic-speech-recognition | jq '.data | [].id'
+uvx speaches-cli registry ls --task automatic-speech-recognition | jq -r '.data[]?.id'
 
 # Downloading a Systran/faster-distil-whisper-small.en model
 uvx speaches-cli model download Systran/faster-distil-whisper-small.en
 
 # Check that the model has been installed
-uvx speaches-cli model ls --task text-to-speech | jq '.data | map(select(.id == "Systran/faster-distil-whisper-small.en"))'
+uvx speaches-cli model ls --task automatic-speech-recognition \
+  | jq -r '.data[]? | select(.id == "Systran/faster-distil-whisper-small.en") | .id'
 ```
 
 ## Usage

--- a/docs/usage/text-to-speech.md
+++ b/docs/usage/text-to-speech.md
@@ -8,13 +8,14 @@
 export SPEACHES_BASE_URL="http://localhost:8000"
 
 # Listing all available TTS models
-uvx speaches-cli registry ls --task text-to-speech | jq '.data | [].id'
+uvx speaches-cli registry ls --task text-to-speech | jq -r '.data[]?.id'
 
 # Downloading a TTS model
 uvx speaches-cli model download speaches-ai/Kokoro-82M-v1.0-ONNX
 
 # Check that the model has been installed
-uvx speaches-cli model ls --task text-to-speech | jq '.data | map(select(.id == "speaches-ai/Kokoro-82M-v1.0-ONNX"))'
+uvx speaches-cli model ls --task text-to-speech \
+  | jq -r '.data[]? | select(.id | contains("Kokoro-82M-v1.0-ONNX")) | .id'
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

This fixes the model download examples in the STT and TTS usage docs.

- Use the ASR task when checking whether the STT model was installed
- Print model IDs directly with `jq -r '.data[]?.id'`
- Make the TTS install check match the Kokoro model ID returned by the models API

Closes #617
Closes #618

## Why

The current STT example checks installed models with `--task text-to-speech`, so users following the speech-to-text docs will not see the downloaded ASR model.

The updated examples also make the `jq` output easier to copy and verify by printing matching model IDs directly instead of JSON arrays.

## Verification

- `uv run mkdocs build --strict`

Note: I also tried running Ruff on the modified files as requested by the contributor instructions, but these files are Markdown, so Ruff attempts to parse them as Python and reports syntax errors.
