### PR TITLE
Fix: ModelId path

### DIFF
--- a/src/speaches/model_aliases.py
+++ b/src/speaches/model_aliases.py
@@ -5,18 +5,32 @@ from typing import Annotated
 
 from pydantic import BeforeValidator, Field
 
-MODEL_ID_ALIASES_PATH = Path("model_aliases.json")  # TODO: make configurable
-
+MODEL_ID_ALIASES_PATH = Path(__file__).resolve().parent / "model_aliases.json"
 
 @lru_cache
-def load_model_id_aliases() -> dict[str, str]:
-    return json.loads(MODEL_ID_ALIASES_PATH.read_text())
+def load_model_id_aliases():
+    if not MODEL_ID_ALIASES_PATH.exists():
+        return {}
 
+    text = MODEL_ID_ALIASES_PATH.read_text().strip()
+
+    if not text:
+        return {}
+
+    try:
+        return json.loads(text)
+    except Exception:
+        return {}
 
 def resolve_model_id_alias(model_id: str) -> str:
     model_id_aliases = load_model_id_aliases()
-    return model_id_aliases.get(model_id, model_id)
 
+    if not isinstance(model_id, str):
+        return str(model_id)
+
+    model_id = model_id.strip()
+
+    return model_id_aliases.get(model_id, model_id)
 
 ModelId = Annotated[
     str,


### PR DESCRIPTION
fixes #655

## a human comment

after spending half a day with #655, I tried to find a solution - if it is not to your liking, I can absolutely accept, what is in the code is mere llm code...

## 🐞 Fix: ModelId path validation crash in `/v1/models/{model_id}`

### Summary

This MR fixes a persistent `422 Unprocessable Entity` error when calling model management endpoints with valid Hugging Face model IDs containing `/` (e.g. `Systran/faster-whisper-medium`).

The failure occurred during FastAPI/Pydantic request validation, before reaching endpoint logic, due to unsafe or brittle handling in the `ModelId` alias resolution path.

---

## 🔍 Root Cause

The issue originated from a combination of:

1. A `BeforeValidator` applied to `ModelId`
2. JSON parsing assumptions in alias/config loading logic
3. Insufficient robustness in handling:
   - empty alias files
   - missing files
   - unexpected input formats during validation

This caused a `json.JSONDecodeError` to be raised during request validation, which FastAPI surfaced as:

```
Value error: Expecting value: line 1 column 1 (char 0)
```

even though the incoming request value was a valid model ID string.

---

## 🛠️ Changes Introduced

### 1. Hardened alias loader

Improved robustness of `model_aliases.json` loading to safely handle:

- missing file
- empty file
- invalid JSON content

```python
def load_model_id_aliases():
    if not MODEL_ID_ALIASES_PATH.exists():
        return {}

    text = MODEL_ID_ALIASES_PATH.read_text().strip()

    if not text:
        return {}

    try:
        return json.loads(text)
    except Exception:
        return {}
```

---

### 2. Hardened alias resolution logic

Ensures that `model_id` is always treated as a safe string and never passed into unsafe parsing logic.

```python
def resolve_model_id_alias(model_id: str) -> str:
    model_id_aliases = load_model_id_aliases()

    if not isinstance(model_id, str):
        return str(model_id)

    model_id = model_id.strip()

    return model_id_aliases.get(model_id, model_id)
```

---

### 3. Safer filesystem-based alias resolution

Moved alias file resolution to a stable module-relative path:

```python
MODEL_ID_ALIASES_PATH = Path(__file__).resolve().parent / "model_aliases.json"
```

---

## 🧪 Verification

### Registry endpoint

```bash
curl http://localhost:8000/v1/models
```

✔ Returns available models successfully

---

### Model download (slash IDs)

```bash
curl -X POST http://localhost:8000/v1/models/Systran%2Ffaster-whisper-tiny
```

✔ Returns `200 OK` / `201 Created`  
✔ Model downloads correctly  
✔ No validation error

---

### Transcription endpoint

```bash
curl -X POST http://localhost:8000/v1/audio/transcriptions \
  -F "file=@/path/to/audio.ogg" \
  -F "model=Systran/faster-whisper-tiny"
```

✔ Works end-to-end after fix

---

## 📌 Impact

- Fixes blocking `422` errors on valid model IDs
- Restores compatibility with Hugging Face model naming (`org/model`)
- Improves resilience of model alias system
- Prevents malformed config files from breaking API validation
- No breaking API changes

---

## 🧠 Notes

This issue highlighted a subtle interaction between:
- FastAPI path parameter validation
- Pydantic `BeforeValidator`
- unsafe JSON parsing assumptions in config loaders

The fix prioritizes robustness and defensive parsing to prevent validation-time crashes from external file state.

---

## 🚀 Suggested follow-ups (optional)

- Add schema validation for `model_aliases.json`
- Log warnings when alias file is invalid instead of silently ignoring
- Add unit tests for:
  - empty alias file
  - missing alias file
  - invalid JSON alias file
- Consider separating alias resolution from request validation layer entirely
