### PR TITLE
feat: add FunASR (SenseVoice/Paraformer) transcription backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,13 @@ dependencies = [
     "opentelemetry-instrumentation-system-metrics>=0.61b0",
 ]
 
+[project.optional-dependencies]
+funasr = [
+    "funasr>=1.1.0",
+    "torch>=2.1.0",
+    "torchaudio>=2.1.0",
+]
+
 [dependency-groups]
 dev = [
   {include-group = "docs"},

--- a/src/speaches/config.py
+++ b/src/speaches/config.py
@@ -21,6 +21,12 @@ class WhisperConfig(BaseModel):
     num_workers: int = 1
 
 
+class FunasrConfig(BaseModel):
+    """Configuration for FunASR models (SenseVoice, Paraformer, ...)."""
+
+    inference_device: Device = "auto"
+
+
 class OrtOptions(BaseModel):
     exclude_providers: list[str] = ["TensorrtExecutionProvider"]
     """
@@ -98,6 +104,7 @@ class Config(BaseSettings):
     """
 
     whisper: WhisperConfig = WhisperConfig()
+    funasr: FunasrConfig = FunasrConfig()
 
     # TODO: remove the underscore prefix from the field name
     _unstable_vad_filter: bool = True

--- a/src/speaches/executors/funasr.py
+++ b/src/speaches/executors/funasr.py
@@ -1,0 +1,190 @@
+"""FunASR transcription executor.
+
+Adds support for Alibaba DAMO Academy's FunASR family of speech-recognition
+models (SenseVoice, Paraformer, ...) as an OpenAI-compatible STT backend.
+
+FunASR models are tagged with ``library_name: funasr`` and
+``pipeline_tag: automatic-speech-recognition`` on the HuggingFace Hub, which is
+how they are matched to this executor.
+
+The ``funasr`` package (and ``torch``) are optional dependencies, so they are
+imported lazily inside the model manager. Install them with::
+
+    pip install speaches[funasr]
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, TypedDict
+
+import huggingface_hub
+import openai.types.audio
+from opentelemetry import trace
+
+from speaches.api_types import Model
+from speaches.audio import resample_audio_data
+from speaches.executors.shared.base_model_manager import BaseModelManager
+from speaches.executors.shared.handler_protocol import (  # noqa: TC001
+    NonStreamingTranscriptionResponse,
+    StreamingTranscriptionEvent,
+    TranscriptionRequest,
+)
+from speaches.hf_utils import (
+    HfModelFilter,
+    extract_language_list,
+    get_cached_model_repos_info,
+    get_model_card_data_from_cached_repo_info,
+    get_model_repo_path,
+)
+from speaches.model_registry import ModelRegistry
+from speaches.tracing import traced, traced_generator
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+    from funasr import AutoModel
+
+    from speaches.config import Device, FunasrConfig
+
+LIBRARY_NAME = "funasr"
+TASK_NAME_TAG = "automatic-speech-recognition"
+SAMPLE_RATE = 16000  # FunASR models operate on 16 kHz mono audio
+
+logger = logging.getLogger(__name__)
+tracer = trace.get_tracer(__name__)
+
+hf_model_filter = HfModelFilter(
+    library_name=LIBRARY_NAME,
+    task=TASK_NAME_TAG,
+)
+
+
+class FunasrModelFiles(TypedDict):
+    model_dir: Path
+
+
+class FunasrModelRegistry(ModelRegistry[Model, FunasrModelFiles]):
+    def list_remote_models(self) -> Generator[Model]:
+        models = huggingface_hub.list_models(**self.hf_model_filter.list_model_kwargs(), cardData=True)
+        for model in models:
+            assert model.created_at is not None and model.card_data is not None, model
+            yield Model(
+                id=model.id,
+                created=int(model.created_at.timestamp()),
+                owned_by=model.id.split("/")[0],
+                language=extract_language_list(model.card_data),
+                task=TASK_NAME_TAG,
+            )
+
+    def list_local_models(self) -> Generator[Model]:
+        cached_model_repos_info = get_cached_model_repos_info()
+        for cached_repo_info in cached_model_repos_info:
+            model_card_data = get_model_card_data_from_cached_repo_info(cached_repo_info)
+            if model_card_data is None:
+                continue
+            if self.hf_model_filter.passes_filter(cached_repo_info.repo_id, model_card_data):
+                yield Model(
+                    id=cached_repo_info.repo_id,
+                    created=int(cached_repo_info.last_modified),
+                    owned_by=cached_repo_info.repo_id.split("/")[0],
+                    language=extract_language_list(model_card_data),
+                    task=TASK_NAME_TAG,
+                )
+
+    def get_model_files(self, model_id: str) -> FunasrModelFiles:
+        repo_path = get_model_repo_path(model_id)
+        if repo_path is None:
+            raise ValueError(f"Model {model_id} not found in the local cache. Download it first.")
+        snapshots_path = repo_path / "snapshots"
+        snapshot_dir = next((p for p in snapshots_path.iterdir() if p.is_dir()), None)
+        if snapshot_dir is None:
+            raise ValueError(f"No snapshot found for model {model_id}.")
+        return FunasrModelFiles(model_dir=snapshot_dir)
+
+    def download_model_files(self, model_id: str) -> None:
+        huggingface_hub.snapshot_download(repo_id=model_id, repo_type="model")
+
+
+funasr_model_registry = FunasrModelRegistry(hf_model_filter=hf_model_filter)
+
+
+class FunasrModelManager(BaseModelManager["AutoModel"]):
+    def __init__(self, ttl: int, funasr_config: FunasrConfig) -> None:
+        super().__init__(ttl)
+        self.funasr_config = funasr_config
+
+    def _resolve_device(self) -> str:
+        device: Device = self.funasr_config.inference_device
+        if device == "auto":
+            import torch
+
+            return "cuda" if torch.cuda.is_available() else "cpu"
+        return device
+
+    def _load_fn(self, model_id: str) -> AutoModel:
+        try:
+            from funasr import AutoModel
+        except ImportError as e:
+            raise ImportError(
+                "The 'funasr' package is required to use FunASR models. Install it with: pip install speaches[funasr]"
+            ) from e
+        model_files = funasr_model_registry.get_model_files(model_id)
+        return AutoModel(
+            model=str(model_files["model_dir"]),
+            device=self._resolve_device(),
+            disable_update=True,
+            disable_pbar=True,
+            disable_log=True,
+        )
+
+    @traced()
+    def handle_non_streaming_transcription_request(
+        self,
+        request: TranscriptionRequest,
+        **_kwargs,
+    ) -> NonStreamingTranscriptionResponse:
+        if request.response_format not in ("text", "json"):
+            raise ValueError(
+                f"'{request.response_format}' response format is not supported for '{request.model}' model."
+            )
+        from funasr.utils.postprocess_utils import rich_transcription_postprocess
+
+        audio_data = request.audio.data
+        if request.audio.sample_rate != SAMPLE_RATE:
+            audio_data = resample_audio_data(audio_data, request.audio.sample_rate, SAMPLE_RATE)
+
+        with self.load_model(request.model) as model:
+            # TODO: warn on unsupported params (temperature, timestamp_granularities, ...)
+            # TODO: use request.speech_segments for chunking long audio
+            results = model.generate(
+                input=audio_data,
+                cache={},
+                language=request.language or "auto",
+                use_itn=True,
+                batch_size_s=60,
+            )
+            text = rich_transcription_postprocess(results[0]["text"])
+
+            match request.response_format:
+                case "text":
+                    return text, "text/plain"
+                case "json":
+                    return openai.types.audio.Transcription(text=text)
+
+    @traced_generator()
+    def handle_streaming_transcription_request(
+        self,
+        request: TranscriptionRequest,
+        **_kwargs,
+    ) -> Generator[StreamingTranscriptionEvent]:
+        raise NotImplementedError(f"'{request.model}' model doesn't support streaming transcription.")
+
+    def handle_transcription_request(
+        self, request: TranscriptionRequest, **kwargs
+    ) -> NonStreamingTranscriptionResponse | Generator[StreamingTranscriptionEvent]:
+        if request.stream:
+            return self.handle_streaming_transcription_request(request, **kwargs)
+        else:
+            return self.handle_non_streaming_transcription_request(request, **kwargs)

--- a/src/speaches/executors/shared/registry.py
+++ b/src/speaches/executors/shared/registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from speaches.executors.funasr import FunasrModelRegistry
 from speaches.executors.kokoro import KokoroModelRegistry
 from speaches.executors.parakeet import NemoConformerTdtModelRegistry
 from speaches.executors.piper import PiperModelRegistry
@@ -17,6 +18,7 @@ from speaches.executors.whisper import WhisperModelRegistry
 if TYPE_CHECKING:
     from speaches.config import Config
 
+from speaches.executors.funasr import FunasrModelManager, funasr_model_registry
 from speaches.executors.kokoro import KokoroModelManager, kokoro_model_registry
 from speaches.executors.parakeet import ParakeetModelManager, parakeet_model_registry
 from speaches.executors.piper import PiperModelManager, piper_model_registry
@@ -41,6 +43,12 @@ class ExecutorRegistry:
             name="parakeet",
             model_manager=ParakeetModelManager(config.stt_model_ttl, config.unstable_ort_opts),
             model_registry=parakeet_model_registry,
+            task="automatic-speech-recognition",
+        )
+        self._funasr_executor = Executor[FunasrModelManager, FunasrModelRegistry](
+            name="funasr",
+            model_manager=FunasrModelManager(config.stt_model_ttl, config.funasr),
+            model_registry=funasr_model_registry,
             task="automatic-speech-recognition",
         )
         self._piper_executor = Executor[PiperModelManager, PiperModelRegistry](
@@ -80,7 +88,7 @@ class ExecutorRegistry:
 
     @property
     def transcription(self):  # noqa: ANN201
-        return (self._whisper_executor, self._parakeet_executor)
+        return (self._whisper_executor, self._parakeet_executor, self._funasr_executor)
 
     @property
     def translation(self):  # noqa: ANN201
@@ -106,6 +114,7 @@ class ExecutorRegistry:
         return (
             self._whisper_executor,
             self._parakeet_executor,
+            self._funasr_executor,
             self._piper_executor,
             self._kokoro_executor,
             self._wespeaker_speaker_embedding_executor,

--- a/tests/funasr_test.py
+++ b/tests/funasr_test.py
@@ -1,0 +1,20 @@
+from huggingface_hub import ModelCardData
+
+from speaches.config import Config
+from speaches.executors.funasr import hf_model_filter
+from speaches.executors.shared.registry import ExecutorRegistry
+
+
+def test_funasr_executor_is_registered() -> None:
+    registry = ExecutorRegistry(Config())
+    assert "funasr" in [executor.name for executor in registry.transcription]
+
+
+def test_funasr_filter_matches_funasr_asr_models() -> None:
+    card_data = ModelCardData(library_name="funasr", pipeline_tag="automatic-speech-recognition")
+    assert hf_model_filter.passes_filter("FunAudioLLM/SenseVoiceSmall", card_data)
+
+
+def test_funasr_filter_rejects_non_funasr_models() -> None:
+    card_data = ModelCardData(library_name="ctranslate2", pipeline_tag="automatic-speech-recognition")
+    assert not hf_model_filter.passes_filter("Systran/faster-whisper-tiny", card_data)


### PR DESCRIPTION
## What

Adds a FunASR transcription executor for FunASR-family models, including SenseVoice and Paraformer, through the existing OpenAI-compatible `/v1/audio/transcriptions` endpoint. Addresses #645.

## Implementation

- Matches Hugging Face model metadata with `library_name: funasr` and `pipeline_tag: automatic-speech-recognition`.
- Registers the executor in `ExecutorRegistry.transcription`.
- Lazy-imports FunASR, with an installation hint when unavailable.
- Uses `rich_transcription_postprocess` to remove rich-text tags from the returned text.
- Supports non-streaming `text` and `json` responses. Streaming, hotword configuration, and timestamp response formats are not implemented.

## Installation And Lock Repair

From this checkout:

```sh
uv sync --frozen --extra funasr
```

The `funasr` extra declares FunASR, Torch, and Torchaudio. Torch is also required by existing base dependencies; this does not make the base installation Torch-free.

The previous lock omitted the declared extra: `uv sync --frozen --extra funasr --dry-run` failed with "Extra 'funasr' is not defined". Regenerating `uv.lock` without `--upgrade` repairs this. The new packages are dependencies reachable from the extra. Tokenizers moves from 0.20.1 to 0.22.2 to satisfy the resolved Transformers 4.57.6 requirement (`>=0.22.0,<=0.23.0`). Other existing package versions and the project's overrides are preserved; uv also simplifies seven existing packages' dependency-edge markers.

## Current Validation

Validated 2026-09-22, at head `eb7221c001716bad8d18c7b3568e3a145c876dc9`, against upstream master `993994f7984bf3fe9655b267448328cf66fccb42`:

- Actual frozen installation into an isolated Python 3.12.3 environment succeeded: 285 packages installed, including FunASR 1.4.16 and matching Torch/Torchaudio 2.8.0+cu128. GPU devices were hidden during validation.
- `uv lock --check --offline` passed (288 packages in the universal lock).
- `python -m pytest tests/funasr_test.py tests/text_utils_test.py -q --timeout=90`: 9 passed, using the repository's native conftest and installed executors, without substituting other executor modules.
- Native imports of `funasr.AutoModel` and `rich_transcription_postprocess` succeeded; a text postprocessing smoke check succeeded.
- Ruff check and format check passed for `src/speaches/executors/funasr.py` and `tests/funasr_test.py`; `git diff --check` passed.

`uv pip check` is **not clean**: it reports three missing `onnxruntime` distributions (GPU variant is installed), aiortc's `av<15` requirement versus locked Av 15.1.0, and missing TorchCodec for pyannote-audio. These correspond to the unchanged upstream ONNX Runtime, Av, and TorchCodec overrides. This repair does not change or waive those constraints.

This validation does not cover model inference, GPU execution, the full test suite, or end-to-end HTTP transcription. No models were downloaded for these checks. Earlier H100 executor-call evidence in the discussion is historical, not validation of this head and not an HTTP route test. No comparative performance claim is made here.
