### PR TITLE
Fix spelling error in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -693,7 +693,7 @@
 
 
 <h1 id="speaches">Speaches</h1>
-<p><code>speaches</code> is an OpenAI API-compatible server supporting streaming transcription, translation, and speech generation. Speach-to-Text is powered by <a href="https://github.com/SYSTRAN/faster-whisper">faster-whisper</a> and for Text-to-Speech <a href="https://github.com/rhasspy/piper">piper</a> and <a href="https://huggingface.co/hexgrad/Kokoro-82M">Kokoro</a> are used. This project aims to be Ollama, but for TTS/STT models.</p>
+<p><code>speaches</code> is an OpenAI API-compatible server supporting streaming transcription, translation, and speech generation. Speech-to-Text is powered by <a href="https://github.com/SYSTRAN/faster-whisper">faster-whisper</a> and for Text-to-Speech <a href="https://github.com/rhasspy/piper">piper</a> and <a href="https://huggingface.co/hexgrad/Kokoro-82M">Kokoro</a> are used. This project aims to be Ollama, but for TTS/STT models.</p>
 <h2 id="features">Features:</h2>
 <ul>
 <li>OpenAI API compatible. All tools and SDKs that work with OpenAI's API should work with <code>speaches</code>.</li>


### PR DESCRIPTION
Corrected the spelling of 'Speach' to 'Speech' in the description.