### PR TITLE
fix(diarization): known-speaker matching on pyannote community-1 + optional-hint semantics

### DIFF
--- a/src/speaches/diarization.py
+++ b/src/speaches/diarization.py
@@ -1,3 +1,6 @@
+from collections.abc import Hashable
+
+import numpy as np
 from pydantic import BaseModel, ConfigDict
 
 from speaches.audio import Audio
@@ -8,3 +11,30 @@ class KnownSpeaker(BaseModel):
     audio: Audio
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+def match_speakers_to_known(
+    avg_embeddings: dict[Hashable, np.ndarray],
+    known_embeddings: dict[str, np.ndarray],
+    threshold: float,
+) -> dict[Hashable, str]:
+    # Map each diarized speaker to the most similar known speaker via cosine similarity.
+    # A diarized speaker is only relabeled when its best match strictly exceeds the threshold;
+    # otherwise it keeps its original label (e.g. SPEAKER_00). This makes known speakers
+    # optional hints: their count does not force additional speakers and unmatched speakers
+    # are not force-labeled with the nearest name.
+    mapping: dict[Hashable, str] = {}
+    for diarized_spk, diarized_emb in avg_embeddings.items():
+        best_name = diarized_spk
+        best_sim = threshold
+        for known_name, known_emb in known_embeddings.items():
+            denom = float(np.linalg.norm(diarized_emb) * np.linalg.norm(known_emb))
+            if denom < 1e-8:
+                continue
+            sim = float(np.dot(diarized_emb, known_emb) / denom)
+            if sim > best_sim:
+                best_sim = sim
+                best_name = known_name
+        mapping[diarized_spk] = best_name
+
+    return mapping

--- a/src/speaches/routers/diarization.py
+++ b/src/speaches/routers/diarization.py
@@ -10,9 +10,9 @@ from pyannote.audio.pipelines.speaker_diarization import DiarizeOutput
 from pydantic import BaseModel
 import torch
 
-from speaches.audio import Audio
+from speaches.audio import Audio, resample_audio_data
 from speaches.dependencies import AudioFileDependency, ExecutorRegistryDependency
-from speaches.diarization import KnownSpeaker
+from speaches.diarization import KnownSpeaker, match_speakers_to_known
 from speaches.model_aliases import ModelId
 from speaches.routers.utils import find_executor_for_model_or_raise, get_model_card_data_or_raise
 from speaches.utils import parse_data_url_to_audio
@@ -31,7 +31,7 @@ class DiarizationSegment(BaseModel):
     end: float
     """End timestamp of the segment in seconds."""
     speaker: str
-    """Speaker label for this segment. When known speakers are provided, the label matches the known speaker name. Otherwise speakers are labeled as SPEAKER_00, SPEAKER_01, etc."""
+    """Speaker label for this segment. When a known speaker reference matches this speaker above the similarity threshold, the label is the known speaker name. Otherwise speakers are labeled as SPEAKER_00, SPEAKER_01, etc."""
 
 
 class DiarizationResponse(BaseModel):
@@ -43,53 +43,49 @@ class DiarizationResponse(BaseModel):
 
 def _map_to_known_speakers(
     pipeline: Pipeline,
-    waveform: torch.Tensor,
-    sample_rate: int,
     diarization: DiarizeOutput,
     known_speakers: list[KnownSpeaker],
+    threshold: float,
 ) -> dict[Hashable, str]:
-    from pyannote.audio import Inference
+    # The community-1 pipeline exposes its speaker embedding model as a callable
+    # PretrainedSpeakerEmbedding (cosine metric). It takes a (batch, channel, samples) tensor at
+    # its own sample rate and returns a (batch, dimension) array. Note: it is NOT a pyannote Model,
+    # so it cannot be wrapped in Inference().
+    embedding = pipeline._embedding  # noqa: SLF001
+    target_sample_rate = embedding.sample_rate
 
-    inference = Inference(pipeline._embedding, window="whole")  # noqa: SLF001
-    main_audio = {"waveform": waveform, "sample_rate": sample_rate}
-
-    # Compute embeddings for reference speakers
+    # Embed each reference clip.
     known_embeddings: dict[str, np.ndarray] = {}
     for ks in known_speakers:
-        ref_waveform = torch.from_numpy(ks.audio.data).unsqueeze(0).float()
-        known_embeddings[ks.name] = np.asarray(
-            inference({"waveform": ref_waveform, "sample_rate": ks.audio.sample_rate})
-        )
-
-    # Collect embeddings per diarized speaker across all their turns
-    speaker_embeddings: dict[str, list[np.ndarray]] = {}
-    speaker_track_gen = diarization.speaker_diarization.itertracks(yield_label=True)
-    speaker_track_gen = cast("Iterator[tuple[Segment, TrackName, Hashable]]", speaker_track_gen)
-    for turn, _, speaker in speaker_track_gen:
         try:
-            emb = np.asarray(inference.crop(main_audio, turn))
-            speaker_embeddings.setdefault(speaker, []).append(emb)  # pyrefly: ignore[no-matching-overload]
+            data = ks.audio.data
+            if ks.audio.sample_rate != target_sample_rate:
+                data = resample_audio_data(data, ks.audio.sample_rate, target_sample_rate)
+            ref_waveform = torch.from_numpy(data).float().reshape(1, 1, -1)
+            emb = np.asarray(embedding(ref_waveform))[0]
         except Exception:
-            logger.exception(f"Failed to extract embedding for speaker {speaker} turn {turn}")
+            logger.exception(f"Failed to compute embedding for known speaker {ks.name}")
+            continue
+        if np.isnan(emb).any():
+            logger.warning(f"Embedding for known speaker {ks.name} contains NaN, skipping")
+            continue
+        known_embeddings[ks.name] = emb
 
-    avg_embeddings = {spk: np.mean(embs, axis=0) for spk, embs in speaker_embeddings.items() if embs}
+    # Reuse the per-speaker centroid embeddings the pipeline already computed during clustering.
+    # They are aligned with diarization.speaker_diarization.labels() and live in the same embedding
+    # space as the reference embeddings, so no re-embedding of the main audio is needed.
+    speaker_embeddings = diarization.speaker_embeddings
+    if speaker_embeddings is None:
+        return {}
+    avg_embeddings: dict[Hashable, np.ndarray] = {}
+    for index, label in enumerate(diarization.speaker_diarization.labels()):
+        if index >= len(speaker_embeddings):
+            break
+        emb = np.asarray(speaker_embeddings[index])
+        if not np.isnan(emb).any():
+            avg_embeddings[label] = emb
 
-    # Match each diarized speaker to the most similar known speaker via cosine similarity
-    mapping: dict[Hashable, str] = {}
-    for diarized_spk, diarized_emb in avg_embeddings.items():
-        best_name = diarized_spk
-        best_sim = -2.0
-        for known_name, known_emb in known_embeddings.items():
-            denom = float(np.linalg.norm(diarized_emb) * np.linalg.norm(known_emb))
-            if denom < 1e-8:
-                continue
-            sim = float(np.dot(diarized_emb, known_emb) / denom)
-            if sim > best_sim:
-                best_sim = sim
-                best_name = known_name
-        mapping[diarized_spk] = best_name
-
-    return mapping
+    return match_speakers_to_known(avg_embeddings, known_embeddings, threshold)
 
 
 @router.post(
@@ -111,6 +107,10 @@ def diarize_audio(
     model: Annotated[ModelId, Form()],
     known_speaker_names: Annotated[list[str] | None, Form(alias="known_speaker_names[]")] = None,
     known_speaker_references: Annotated[list[str] | None, Form(alias="known_speaker_references[]")] = None,
+    known_speaker_threshold: Annotated[float, Form()] = 0.5,
+    num_speakers: Annotated[int | None, Form()] = None,
+    min_speakers: Annotated[int | None, Form()] = None,
+    max_speakers: Annotated[int | None, Form()] = None,
     response_format: Annotated[Literal["json", "rttm"] | None, Form()] = "json",
 ) -> Response:
     known_speakers: list[KnownSpeaker] | None = None
@@ -128,15 +128,20 @@ def diarize_audio(
 
     with executor.model_manager.load_model(model) as pipeline:
         waveform = torch.from_numpy(audio.data).unsqueeze(0).float()
-        diarization = pipeline({"waveform": waveform, "sample_rate": audio.sample_rate})
+        diarization_kwargs: dict[str, int] = {}
+        if num_speakers is not None:
+            diarization_kwargs["num_speakers"] = num_speakers
+        if min_speakers is not None:
+            diarization_kwargs["min_speakers"] = min_speakers
+        if max_speakers is not None:
+            diarization_kwargs["max_speakers"] = max_speakers
+        diarization = pipeline({"waveform": waveform, "sample_rate": audio.sample_rate}, **diarization_kwargs)
         assert isinstance(diarization, DiarizeOutput), f"Expected DiarizeOutput, got {type(diarization)}"
 
         speaker_mapping: dict[Hashable, str] | None = None
         if known_speakers:
             try:
-                speaker_mapping = _map_to_known_speakers(
-                    pipeline, waveform, audio.sample_rate, diarization, known_speakers
-                )
+                speaker_mapping = _map_to_known_speakers(pipeline, diarization, known_speakers, known_speaker_threshold)
             except Exception:
                 logger.exception("Failed to map diarized speakers to known speakers, using default labels")
 

--- a/tests/diarization_matching_test.py
+++ b/tests/diarization_matching_test.py
@@ -1,0 +1,69 @@
+import numpy as np
+
+from speaches.diarization import match_speakers_to_known
+
+
+def test_match_names_matching_reference() -> None:
+    known = {
+        "alice": np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        "bob": np.array([0.0, 1.0, 0.0], dtype=np.float32),
+    }
+    avg = {"SPEAKER_00": np.array([0.99, 0.01, 0.0], dtype=np.float32)}
+
+    mapping = match_speakers_to_known(avg, known, threshold=0.5)
+
+    assert mapping == {"SPEAKER_00": "alice"}
+
+
+def test_match_keeps_label_when_below_threshold() -> None:
+    known = {
+        "alice": np.array([1.0, 0.0, 0.0], dtype=np.float32),
+        "bob": np.array([0.0, 1.0, 0.0], dtype=np.float32),
+    }
+    # Orthogonal to every reference, so cosine similarity is 0, below the threshold.
+    avg = {"SPEAKER_00": np.array([0.0, 0.0, 1.0], dtype=np.float32)}
+
+    mapping = match_speakers_to_known(avg, known, threshold=0.5)
+
+    assert mapping == {"SPEAKER_00": "SPEAKER_00"}
+
+
+def test_extra_references_do_not_add_or_rename_speakers() -> None:
+    # A catalog of references, only one of which is actually present in the audio.
+    known = {
+        "alice": np.array([1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+        "bob": np.array([0.0, 1.0, 0.0, 0.0], dtype=np.float32),
+        "carol": np.array([0.0, 0.0, 1.0, 0.0], dtype=np.float32),
+        "dave": np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32),
+    }
+    # Two real speakers: one is alice, the other resembles none of the references.
+    avg = {
+        "SPEAKER_00": np.array([1.0, 0.02, 0.0, 0.0], dtype=np.float32),
+        "SPEAKER_01": np.array([0.5, 0.5, 0.5, 0.5], dtype=np.float32),
+    }
+
+    mapping = match_speakers_to_known(avg, known, threshold=0.8)
+
+    # The speaker count is unchanged (one entry per diarized speaker) and the unmatched
+    # speaker keeps its label rather than being force-named from the catalog.
+    assert len(mapping) == 2
+    assert mapping["SPEAKER_00"] == "alice"
+    assert mapping["SPEAKER_01"] == "SPEAKER_01"
+
+
+def test_threshold_gates_the_match() -> None:
+    known = {"alice": np.array([1.0, 0.0], dtype=np.float32)}
+    # Unit vector whose cosine similarity with "alice" is about 0.6.
+    avg = {"SPEAKER_00": np.array([0.6, 0.8], dtype=np.float32)}
+
+    # A threshold above the similarity keeps the label; one below names the speaker.
+    assert match_speakers_to_known(avg, known, threshold=0.7) == {"SPEAKER_00": "SPEAKER_00"}
+    assert match_speakers_to_known(avg, known, threshold=0.5) == {"SPEAKER_00": "alice"}
+
+
+def test_zero_embedding_is_skipped() -> None:
+    known = {"alice": np.array([0.0, 0.0], dtype=np.float32)}
+    avg = {"SPEAKER_00": np.array([1.0, 0.0], dtype=np.float32)}
+
+    # A degenerate zero-norm reference cannot match; the speaker keeps its label.
+    assert match_speakers_to_known(avg, known, threshold=0.5) == {"SPEAKER_00": "SPEAKER_00"}


### PR DESCRIPTION
This was mostly done by Opus. It was reviewed by me, but I'm not a python guy and aware of pull request/contribution policies on this repo, so open to feedback. I've reviewed the changed code and tested this in my app usage scenarios.

---

Summary — Known-speaker matching is broken on the pyannote community-1 pipeline: _map_to_known_speakers wraps pipeline._embedding in Inference, but community-1's embedding is a callable PretrainedSpeakerEmbedding (not a Model), so every request with references raises AttributeError and falls back to all-SPEAKER_NN. This fixes that and makes known speakers optional hints.

Changes
- Fix the embedding regression (call pipeline._embedding directly; reuse the pipeline's speaker_embeddings centroids).
- Add known_speaker_threshold (default 0.5) — unmatched speakers keep SPEAKER_NN; reference count no longer dictates speaker count.
- Add num_speakers/min_speakers/max_speakers params.
- Extract pure match_speakers_to_known + model-free unit tests.

Validation — Real 42-min 3-speaker recording + 12 references (3 real + 9 extras): the 3 real speakers named, 9 extras unmatched, exactly 3 speakers, durations within ~1% of ground truth.

Plus the two out-of-scope notes (the [] alias quirk and the sample-rate discard).

Closes #661 