### PR TITLE
fix: guard RTF division in debug log for zero-duration audio

### DIFF
--- a/src/speaches/dependencies.py
+++ b/src/speaches/dependencies.py
@@ -100,7 +100,10 @@ def audio_file_dependency(
             audio_data = cast("np.typing.NDArray[float32]", decode_audio(file.file, sampling_rate=16000))
         elapsed = time.perf_counter() - start
         audio = Audio(audio_data, sample_rate=16000, name=Path(file.filename).stem if file.filename else None)
-        logger.debug(f"Decoded {audio.duration}s of audio in {elapsed:.5f}s (RTF: {elapsed / audio.duration})")
+        if audio.duration > 0:
+            logger.debug(f"Decoded {audio.duration}s of audio in {elapsed:.5f}s (RTF: {elapsed / audio.duration:.5f})")
+        else:
+            logger.debug(f"Decoded {audio.duration}s of audio in {elapsed:.5f}s (RTF: n/a)")
         return audio
     except av.error.InvalidDataError as e:
         raise HTTPException(

--- a/tests/dependencies_test.py
+++ b/tests/dependencies_test.py
@@ -1,0 +1,26 @@
+import io
+
+from fastapi import UploadFile
+import numpy as np
+import pytest
+
+from speaches.audio import Audio
+from speaches.dependencies import audio_file_dependency
+
+
+def test_zero_duration_audio_does_not_crash(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression test for https://github.com/speaches-ai/speaches/issues/667
+    # A well-formed but zero-duration container decodes to an empty sample array;
+    # decode_audio() succeeds, so the av.error.* handlers are not triggered. The
+    # RTF debug log line then eagerly evaluated `elapsed / audio.duration` and
+    # crashed with ZeroDivisionError — even when debug logging was disabled.
+    monkeypatch.setattr(
+        "speaches.dependencies.decode_audio",
+        lambda *args, **kwargs: np.array([], dtype=np.float32),
+    )
+    upload_file = UploadFile(file=io.BytesIO(b""), filename="empty.wav")
+
+    audio = audio_file_dependency(upload_file)
+
+    assert isinstance(audio, Audio)
+    assert audio.duration == 0.0

--- a/tests/dependencies_test.py
+++ b/tests/dependencies_test.py
@@ -16,7 +16,7 @@ def test_zero_duration_audio_does_not_crash(monkeypatch: pytest.MonkeyPatch) -> 
     # crashed with ZeroDivisionError — even when debug logging was disabled.
     monkeypatch.setattr(
         "speaches.dependencies.decode_audio",
-        lambda *args, **kwargs: np.array([], dtype=np.float32),
+        lambda _file, **_kwargs: np.array([], dtype=np.float32),
     )
     upload_file = UploadFile(file=io.BytesIO(b""), filename="empty.wav")
 


### PR DESCRIPTION
Fixes #667

## Problem

Uploading a well-formed but zero-duration audio file (e.g. a header-only WAV with 0 samples) to `POST /v1/audio/transcriptions` returns HTTP 500 instead of the pre-0.9.0 clean `200` with empty text.

Root cause: the RTF debug log line in `audio_file_dependency` uses an eager f-string:

```python
logger.debug(f"Decoded {audio.duration}s of audio in {elapsed:.5f}s (RTF: {elapsed / audio.duration})")
```

Because f-strings evaluate eagerly, `elapsed / audio.duration` runs even when debug logging is disabled (`log_level` does not mitigate it). `audio.duration == 0` is reachable: a well-formed container that decodes to an empty sample array makes `decode_audio()` succeed (so the `av.error.*` handlers don't fire) and returns a zero-length result. The `ZeroDivisionError` is then caught by the generic `except Exception` handler, which turns it into a 500.

## Fix

Guard the division with `audio.duration > 0`. Zero-duration uploads now flow through to the normal empty-transcription path, restoring the pre-rc behavior; normal files still log RTF as before.

## Test

Added `tests/dependencies_test.py` with a mock-based regression test that feeds a zero-duration sample array through `audio_file_dependency` and asserts no crash and `duration == 0.0`.
