### PR TITLE
fix(kokoro): catch unsupported language RuntimeError and return 422

### DIFF
--- a/src/speaches/executors/kokoro.py
+++ b/src/speaches/executors/kokoro.py
@@ -219,12 +219,18 @@ class KokoroModelManager(BaseModelManager[Kokoro]):
         voice_language = next(v.language for v in VOICES if v.name == request.voice)
         with self.load_model(request.model) as tts:
             start = time.perf_counter()
-            async_stream = tts.create_stream(
-                request.text,
-                request.voice,
-                lang=voice_language,
-                speed=request.speed,
-            )
+            try:
+                async_stream = tts.create_stream(
+                    request.text,
+                    request.voice,
+                    lang=voice_language,
+                    speed=request.speed,
+                )
+            except RuntimeError as e:
+                if "not supported" in str(e):
+                    msg = f"Language '{voice_language}' is not supported by the phonemizer backend for voice '{request.voice}'. {e}"
+                    raise ValueError(msg) from e
+                raise
             # HACK: converting an async generator to a sync generator
             sync_stream = async_to_sync_generator(async_stream)
             for audio_data, _ in sync_stream:

--- a/src/speaches/routers/speech.py
+++ b/src/speaches/routers/speech.py
@@ -120,5 +120,4 @@ def synthesize(
     except ValueError as e:
         if "speed must be between" in str(e):
             logger.warning("Unsupported speed value requested for speech synthesis")
-            raise HTTPException(status_code=422, detail=str(e)) from e
-        raise
+        raise HTTPException(status_code=422, detail=str(e)) from e


### PR DESCRIPTION
## Summary

When a Kokoro voice uses a language not supported by the phonemizer backend (e.g. Chinese `zh` with espeak), the `RuntimeError` was unhandled, causing a **500 Internal Server Error**.

This PR fixes the issue by:

1. **`kokoro.py`**: Catching `RuntimeError` with `'not supported'` in the message during `tts.create_stream()` and re-raising as `ValueError` with a clear error message identifying the unsupported language and voice.

2. **`speech.py`**: Generalizing the `ValueError` handling in the speech router to return **422** for all validation errors (not just speed-related ones), since any `ValueError` from the handler represents invalid client input.

### Before (500 error)
```
RuntimeError: language "zh" is not supported by the espeak backend
```

### After (422 with clear message)
```json
{
  "detail": "Language 'zh' is not supported by the phonemizer backend for voice 'zf_xiaobei'. language \"zh\" is not supported by the espeak backend"
}
```

Closes #647