### PR TITLE
fix(parakeet): download config.json and ONNX external-data sidecars

### DIFF
--- a/src/speaches/executors/parakeet.py
+++ b/src/speaches/executors/parakeet.py
@@ -98,7 +98,16 @@ class NemoConformerTdtModelRegistry(ModelRegistry[Model, NemoConformerTdtModelFi
         )
 
     def download_model_files(self, model_id: str) -> None:
+        # Mirror onnx-asr's loader (onnx_asr/loader.py) so the snapshot contains everything the
+        # model needs at load time: config.json is required by get_model_files() above, and ONNX
+        # external-data sidecars (e.g. encoder-model.onnx.data) are required by onnxruntime.
+        # Without them, offline (HF_HUB_OFFLINE=1) loading fails despite the download reporting success.
         allow_patterns = list(NemoConformerTdt._get_model_files(quantization=None).values())  # noqa: SLF001
+        allow_patterns = [
+            "config.json",
+            *allow_patterns,
+            *(str(path.with_suffix(".onnx?data")) for file in allow_patterns if (path := Path(file)).suffix == ".onnx"),
+        ]
 
         _model_repo_path_str = huggingface_hub.snapshot_download(
             repo_id=model_id, repo_type="model", allow_patterns=[*allow_patterns, "README.md"]


### PR DESCRIPTION
Fixes #657

## Problem

`download_model_files()` for Parakeet (NemoConformerTdt) models builds `allow_patterns` only from onnx-asr's private `_get_model_files()` values (`encoder-model.onnx`, `decoder_joint-model.onnx`, `vocab.txt`) plus `README.md`. This silently omits:

- `config.json` — required by speaches' own `get_model_files()` (`next(... == "config.json")` raises `StopIteration` when absent)
- `*.onnx.data` — ONNX external weights (e.g. `encoder-model.onnx.data`, 2.4 GB); onnxruntime cannot create the encoder session without it

Result: `POST /v1/models/{model_id}` reports "downloaded" but the snapshot (~110 MB of ~2.5 GB) cannot load under `HF_HUB_OFFLINE=1`; with hub access, onnx-asr silently re-downloads the missing 2.4 GB on first transcription, defeating the pre-download endpoint.

## Fix

Mirror onnx-asr's own loader pattern list (`onnx_asr/loader.py`): add `config.json` plus an `".onnx?data"` glob for each ONNX entry point (the `?` matches the `.` in `encoder-model.onnx.data`).

## Verification

- Pattern matching verified against the real `istupakov/parakeet-tdt-0.6b-v3-onnx` repo file list: old code matched only 4/7 files (dropping `config.json`, `encoder-model.onnx.data`, `nemo128.onnx`); new code matches everything load-bearing (only the non-load-bearing `nemo128.onnx`, which onnx-asr 0.7.0 bundles internally, is skipped).
- `python3 -m py_compile` on the changed file passes.