### PR TITLE
fix: keep the model in `loaded_models` when an unload is refused

### DIFF
--- a/src/speaches/executors/shared/base_model_manager.py
+++ b/src/speaches/executors/shared/base_model_manager.py
@@ -129,7 +129,12 @@ class BaseModelManager[T](ABC):
             model = self.loaded_models.get(model_id)
             if model is None:
                 raise KeyError(f"Model {model_id} not found")
-            del self.loaded_models[model_id]
+        # Removing the entry is `unload()`'s job, via `model_unloaded_callback`.
+        # Doing it here instead meant a refused unload -- `SelfDisposingModel.unload()`
+        # raises while `ref_count > 0` -- left the model absent from `loaded_models`,
+        # and therefore from `GET /api/ps`, while its weights were still resident and
+        # no longer reachable by `DELETE /api/ps/{model_id}`. `self._lock` is released
+        # before `unload()` runs, so the callback can re-acquire it.
         model.unload()
 
     def load_model(self, model_id: str) -> SelfDisposingModel[T]:

--- a/src/speaches/executors/shared/base_model_manager.py
+++ b/src/speaches/executors/shared/base_model_manager.py
@@ -40,7 +40,7 @@ class SelfDisposingModel[T]:
         model_id: str,
         load_fn: Callable[[], T],
         ttl: int,
-        model_unloaded_callback: Callable[[str], None] | None = None,
+        model_unloaded_callback: Callable[[SelfDisposingModel[T]], None] | None = None,
     ) -> None:
         self.model_id = model_id
         self.load_fn = load_fn
@@ -51,6 +51,7 @@ class SelfDisposingModel[T]:
         self.rlock = threading.RLock()
         self.expire_timer: threading.Timer | None = None
         self.model: T | None = None
+        self.unloaded = False
 
     def unload(self) -> None:
         with self.rlock:
@@ -61,10 +62,18 @@ class SelfDisposingModel[T]:
             if self.expire_timer:
                 self.expire_timer.cancel()
             self.model = None
+            # Mark the handle dead while `rlock` is still held, so a thread
+            # already holding it cannot enter `__enter__` afterwards and
+            # reload weights the registry no longer tracks.
+            self.unloaded = True
             gc.collect()
             logger.info(f"Model {self.model_id} unloaded")
-            if self.model_unloaded_callback is not None:
-                self.model_unloaded_callback(self.model_id)
+        # The callback takes the manager's `_lock`, and `unload_model` holds
+        # that lock across `unload()`. Running the callback inside `rlock`
+        # would hold the locks in the opposite order and could deadlock, so
+        # it fires only after `rlock` is released.
+        if self.model_unloaded_callback is not None:
+            self.model_unloaded_callback(self)
 
     def _load(self) -> None:
         with self.rlock:
@@ -83,6 +92,7 @@ class SelfDisposingModel[T]:
             logger.debug(f"Incremented ref count for {self.model_id}, {self.ref_count=}")
 
     def _decrement_ref(self) -> None:
+        unload_now = False
         with self.rlock:
             self.ref_count -= 1
             logger.debug(f"Decremented ref count for {self.model_id}, {self.ref_count=}")
@@ -93,12 +103,19 @@ class SelfDisposingModel[T]:
                     self.expire_timer.start()
                 elif self.ttl == 0:
                     logger.info(f"Model {self.model_id} is idle, unloading immediately")
-                    self.unload()
+                    unload_now = True
                 else:
                     logger.info(f"Model {self.model_id} is idle, not unloading")
+        # `unload()` must not run while `rlock` is still held: its callback
+        # takes the manager `_lock`, and `unload_model` already runs
+        # `_lock` -> `rlock`, so nesting the other order can deadlock.
+        if unload_now:
+            self.unload()
 
     def __enter__(self) -> T:
         with self.rlock:
+            if self.unloaded:
+                raise ValueError(f"Model {self.model_id} has been unloaded")
             if self.model is None:
                 self._load()
             self._increment_ref()
@@ -113,39 +130,56 @@ class BaseModelManager[T](ABC):
     def __init__(self, ttl: int) -> None:
         self.ttl = ttl
         self.loaded_models: OrderedDict[str, SelfDisposingModel[T]] = OrderedDict()
-        self._lock = threading.Lock()
+        # RLock because `_handle_model_unloaded` re-enters it on the same
+        # thread: `unload_model` holds `_lock` across `model.unload()`, and
+        # `unload()` fires this callback inside that critical section.
+        self._lock = threading.RLock()
 
     @abstractmethod
     def _load_fn(self, model_id: str) -> T:
         pass
 
-    def _handle_model_unloaded(self, model_id: str) -> None:
+    def _handle_model_unloaded(self, model: SelfDisposingModel[T]) -> None:
         with self._lock:
-            if model_id in self.loaded_models:
-                del self.loaded_models[model_id]
+            # Remove the entry only if it still points at the handle that was
+            # unloaded: `load_model` may already have replaced a dead entry
+            # with a fresh one, and deleting that would orphan live weights.
+            if self.loaded_models.get(model.model_id) is model:
+                del self.loaded_models[model.model_id]
 
     def unload_model(self, model_id: str) -> None:
         with self._lock:
             model = self.loaded_models.get(model_id)
             if model is None:
                 raise KeyError(f"Model {model_id} not found")
-        # Removing the entry is `unload()`'s job, via `model_unloaded_callback`.
-        # Doing it here instead meant a refused unload -- `SelfDisposingModel.unload()`
-        # raises while `ref_count > 0` -- left the model absent from `loaded_models`,
-        # and therefore from `GET /api/ps`, while its weights were still resident and
-        # no longer reachable by `DELETE /api/ps/{model_id}`. `self._lock` is released
-        # before `unload()` runs, so the callback can re-acquire it.
-        model.unload()
+            # `_lock` is held across `unload()` so `load_model` can neither
+            # hand out the handle being torn down nor see a registry that
+            # still lists it: acquisition and removal are serialized.
+            # Removing the entry stays `unload()`'s job, via
+            # `model_unloaded_callback` -- a refused unload (`ref_count > 0`)
+            # raises before the callback runs, leaving the model registered,
+            # listed by `GET /api/ps`, and reachable by a later
+            # `DELETE /api/ps/{model_id}` retry.
+            model.unload()
 
     def load_model(self, model_id: str) -> SelfDisposingModel[T]:
         with self._lock:
-            if model_id in self.loaded_models:
+            model = self.loaded_models.get(model_id)
+            if model is not None and model.unloaded:
+                # A TTL unload can finish its teardown while the entry is
+                # still present: `unload()` releases `rlock` before its
+                # callback removes it. Drop the dead handle rather than
+                # returning it -- its `__enter__` would only raise.
+                del self.loaded_models[model_id]
+                model = None
+            if model is None:
+                model = SelfDisposingModel[T](
+                    model_id,
+                    load_fn=lambda: self._load_fn(model_id),
+                    ttl=self.ttl,
+                    model_unloaded_callback=self._handle_model_unloaded,
+                )
+                self.loaded_models[model_id] = model
+            else:
                 logger.debug(f"{model_id} model already loaded")
-                return self.loaded_models[model_id]
-            self.loaded_models[model_id] = SelfDisposingModel[T](
-                model_id,
-                load_fn=lambda: self._load_fn(model_id),
-                ttl=self.ttl,
-                model_unloaded_callback=self._handle_model_unloaded,
-            )
-            return self.loaded_models[model_id]
+            return model

--- a/src/speaches/executors/shared/base_model_manager.py
+++ b/src/speaches/executors/shared/base_model_manager.py
@@ -59,21 +59,26 @@ class SelfDisposingModel[T]:
                 raise ValueError(f"Model {self.model_id} is not loaded. {self.ref_count=}")
             if self.ref_count > 0:
                 raise ValueError(f"Model {self.model_id} is still in use. {self.ref_count=}")
-            if self.expire_timer:
-                self.expire_timer.cancel()
-            self.model = None
-            # Mark the handle dead while `rlock` is still held, so a thread
-            # already holding it cannot enter `__enter__` afterwards and
-            # reload weights the registry no longer tracks.
-            self.unloaded = True
-            gc.collect()
-            logger.info(f"Model {self.model_id} unloaded")
+            self._unload_locked()
         # The callback takes the manager's `_lock`, and `unload_model` holds
         # that lock across `unload()`. Running the callback inside `rlock`
         # would hold the locks in the opposite order and could deadlock, so
         # it fires only after `rlock` is released.
         if self.model_unloaded_callback is not None:
             self.model_unloaded_callback(self)
+
+    def _unload_locked(self) -> None:
+        # Caller holds `rlock` and has already checked the model is resident
+        # and unused.
+        if self.expire_timer:
+            self.expire_timer.cancel()
+        self.model = None
+        # Mark the handle dead while `rlock` is still held, so a thread
+        # already holding it cannot enter `__enter__` afterwards and
+        # reload weights the registry no longer tracks.
+        self.unloaded = True
+        gc.collect()
+        logger.info(f"Model {self.model_id} unloaded")
 
     def _load(self) -> None:
         with self.rlock:
@@ -92,7 +97,7 @@ class SelfDisposingModel[T]:
             logger.debug(f"Incremented ref count for {self.model_id}, {self.ref_count=}")
 
     def _decrement_ref(self) -> None:
-        unload_now = False
+        unloaded = False
         with self.rlock:
             self.ref_count -= 1
             logger.debug(f"Decremented ref count for {self.model_id}, {self.ref_count=}")
@@ -103,14 +108,20 @@ class SelfDisposingModel[T]:
                     self.expire_timer.start()
                 elif self.ttl == 0:
                     logger.info(f"Model {self.model_id} is idle, unloading immediately")
-                    unload_now = True
+                    if self.model is not None:
+                        # Tear down inside this `rlock` hold. Releasing it
+                        # first would let another request enter the handle and
+                        # bump `ref_count`, turning this request's `__exit__`
+                        # into a 500 for a call that succeeded.
+                        self._unload_locked()
+                        unloaded = True
                 else:
                     logger.info(f"Model {self.model_id} is idle, not unloading")
-        # `unload()` must not run while `rlock` is still held: its callback
-        # takes the manager `_lock`, and `unload_model` already runs
-        # `_lock` -> `rlock`, so nesting the other order can deadlock.
-        if unload_now:
-            self.unload()
+        # The callback takes the manager `_lock`, so it must not run while
+        # `rlock` is held: `unload_model` already runs `_lock` -> `rlock`,
+        # and nesting the other order can deadlock.
+        if unloaded and self.model_unloaded_callback is not None:
+            self.model_unloaded_callback(self)
 
     def __enter__(self) -> T:
         with self.rlock:

--- a/tests/base_model_manager_test.py
+++ b/tests/base_model_manager_test.py
@@ -1,0 +1,63 @@
+"""Unit tests for `BaseModelManager`'s registry bookkeeping.
+
+No model download and no HTTP client, so these run in milliseconds anywhere.
+"""
+
+import threading
+
+import pytest
+
+from speaches.executors.shared.base_model_manager import BaseModelManager
+
+
+class FakeModelManager(BaseModelManager[dict]):
+    def _load_fn(self, model_id: str) -> dict:
+        return {"model_id": model_id}
+
+
+@pytest.fixture
+def manager() -> FakeModelManager:
+    m = FakeModelManager(ttl=300)
+    yield m
+    for thread in threading.enumerate():
+        if isinstance(thread, threading.Timer):
+            thread.cancel()
+
+
+def test_unload_model_removes_the_entry_on_success(manager: FakeModelManager) -> None:
+    handle = manager.load_model("m")
+    with handle:
+        pass
+    manager.unload_model("m")
+    assert handle.model is None
+    assert "m" not in manager.loaded_models
+
+
+def test_unload_model_raises_for_an_unknown_model(manager: FakeModelManager) -> None:
+    with pytest.raises(KeyError):
+        manager.unload_model("does-not-exist")
+
+
+def test_unload_model_keeps_the_entry_when_the_model_is_in_use(manager: FakeModelManager) -> None:
+    """A refused unload must not remove the model from `loaded_models`.
+
+    `unload_model` used to delete the entry before calling `unload()`, which
+    raises while `ref_count > 0`. The caller got the error, but the model was
+    already gone from `loaded_models` -- so `GET /api/ps` stopped listing it
+    while its weights were still resident, and `DELETE /api/ps/{model_id}`
+    could only answer 404 from then on. The memory was unreachable until the
+    model's own TTL timer happened to fire.
+    """
+    handle = manager.load_model("m")
+    with handle:
+        with pytest.raises(ValueError, match="still in use"):
+            manager.unload_model("m")
+
+        assert "m" in manager.loaded_models, "a refused unload dropped the model from the registry"
+        assert handle.model is not None, "nothing was actually unloaded"
+
+    # Still addressable afterwards, so a retry succeeds.
+    assert "m" in manager.loaded_models
+    manager.unload_model("m")
+    assert handle.model is None
+    assert "m" not in manager.loaded_models

--- a/tests/base_model_manager_test.py
+++ b/tests/base_model_manager_test.py
@@ -1,13 +1,13 @@
-"""Unit tests for `BaseModelManager`'s registry bookkeeping.
-
-No model download and no HTTP client, so these run in milliseconds anywhere.
-"""
+# Unit tests for `BaseModelManager`'s registry bookkeeping.
+#
+# No model download and no HTTP client, so these run in milliseconds anywhere.
 
 import threading
+import time
 
 import pytest
 
-from speaches.executors.shared.base_model_manager import BaseModelManager
+from speaches.executors.shared.base_model_manager import BaseModelManager, SelfDisposingModel
 
 
 class FakeModelManager(BaseModelManager[dict]):
@@ -39,15 +39,14 @@ def test_unload_model_raises_for_an_unknown_model(manager: FakeModelManager) -> 
 
 
 def test_unload_model_keeps_the_entry_when_the_model_is_in_use(manager: FakeModelManager) -> None:
-    """A refused unload must not remove the model from `loaded_models`.
-
-    `unload_model` used to delete the entry before calling `unload()`, which
-    raises while `ref_count > 0`. The caller got the error, but the model was
-    already gone from `loaded_models` -- so `GET /api/ps` stopped listing it
-    while its weights were still resident, and `DELETE /api/ps/{model_id}`
-    could only answer 404 from then on. The memory was unreachable until the
-    model's own TTL timer happened to fire.
-    """
+    # A refused unload must not remove the model from `loaded_models`.
+    #
+    # `unload_model` used to delete the entry before calling `unload()`, which
+    # raises while `ref_count > 0`. The caller got the error, but the model was
+    # already gone from `loaded_models` -- so `GET /api/ps` stopped listing it
+    # while its weights were still resident, and `DELETE /api/ps/{model_id}`
+    # could only answer 404 from then on. The memory was unreachable until the
+    # model's own TTL timer happened to fire.
     handle = manager.load_model("m")
     with handle:
         with pytest.raises(ValueError, match="still in use"):
@@ -61,3 +60,72 @@ def test_unload_model_keeps_the_entry_when_the_model_is_in_use(manager: FakeMode
     manager.unload_model("m")
     assert handle.model is None
     assert "m" not in manager.loaded_models
+
+
+def test_load_model_waits_out_an_in_flight_unload(manager: FakeModelManager) -> None:
+    # While `unload_model` holds the registry lock across `unload()`, a
+    # concurrent `load_model` must wait for the entry to be removed rather
+    # than receive the handle being torn down -- otherwise it would reload
+    # weights into a handle the registry no longer tracks.
+    first = manager.load_model("m")
+    with first:
+        pass
+
+    unload_started = threading.Event()
+    finish_unload = threading.Event()
+    original_unload = first.unload
+
+    def gated_unload() -> None:
+        unload_started.set()
+        finish_unload.wait(timeout=10)
+        original_unload()
+
+    first.unload = gated_unload
+
+    unloader = threading.Thread(target=manager.unload_model, args=("m",))
+    unloader.start()
+    assert unload_started.wait(timeout=10)
+
+    loaded: list[SelfDisposingModel[dict]] = []
+    loader = threading.Thread(target=lambda: loaded.append(manager.load_model("m")))
+    loader.start()
+    time.sleep(0.2)
+    assert not loaded, "load_model returned a handle while its unload was in flight"
+    finish_unload.set()
+    unloader.join(timeout=10)
+    loader.join(timeout=10)
+
+    second = loaded[0]
+    assert second is not first
+    assert manager.loaded_models["m"] is second
+    with second as model:
+        assert model == {"model_id": "m"}
+    with pytest.raises(ValueError, match="has been unloaded"), first:
+        pass
+
+
+def test_load_model_replaces_a_dead_entry_before_its_unload_callback_lands(manager: FakeModelManager) -> None:
+    # `SelfDisposingModel.unload` fires its callback after releasing `rlock`,
+    # so a TTL unload leaves the registry entry present-but-dead for a moment.
+    # A `load_model` in that gap must swap in a fresh handle, and the late
+    # callback must not delete the replacement.
+    first = manager.load_model("m")
+    with first:
+        pass
+
+    loaded_during_callback: list[SelfDisposingModel[dict]] = []
+    original_callback = first.model_unloaded_callback
+    assert original_callback is not None
+
+    def load_inside_callback(model: SelfDisposingModel[dict]) -> None:
+        loaded_during_callback.append(manager.load_model("m"))
+        original_callback(model)
+
+    first.model_unloaded_callback = load_inside_callback
+    first.unload()  # the path a TTL timer takes
+
+    second = loaded_during_callback[0]
+    assert second is not first
+    assert manager.loaded_models["m"] is second
+    with second as model:
+        assert model == {"model_id": "m"}

--- a/tests/base_model_manager_test.py
+++ b/tests/base_model_manager_test.py
@@ -62,6 +62,19 @@ def test_unload_model_keeps_the_entry_when_the_model_is_in_use(manager: FakeMode
     assert "m" not in manager.loaded_models
 
 
+def test_zero_ttl_unloads_and_deregisters_on_exit() -> None:
+    # ttl=0 tears the model down inside the `__exit__` lock hold, so the
+    # registry entry is gone by the time the with-block returns.
+    manager = FakeModelManager(ttl=0)
+    handle = manager.load_model("m")
+    with handle:
+        pass
+    assert handle.model is None
+    assert "m" not in manager.loaded_models
+    with pytest.raises(ValueError, match="has been unloaded"), handle:
+        pass
+
+
 def test_load_model_waits_out_an_in_flight_unload(manager: FakeModelManager) -> None:
     # While `unload_model` holds the registry lock across `unload()`, a
     # concurrent `load_model` must wait for the entry to be removed rather


### PR DESCRIPTION
### The problem

`BaseModelManager.unload_model` removes the registry entry *before* asking the model to unload:

```python
def unload_model(self, model_id: str) -> None:
    with self._lock:
        model = self.loaded_models.get(model_id)
        if model is None:
            raise KeyError(f"Model {model_id} not found")
        del self.loaded_models[model_id]   # <-- removed first
    model.unload()                         # <-- can raise
```

`SelfDisposingModel.unload()` raises `ValueError` when `ref_count > 0` ("still in use"), which `DELETE /api/ps/{model_id}` correctly turns into a `409`. But by then the entry is already gone, so the refusal leaves the model in a state nothing can address:

- `GET /api/ps` no longer lists it,
- its weights are still resident,
- `DELETE /api/ps/{model_id}` answers `404` from then on,
- and only the model's own `expire_timer` (`*_model_ttl`) can ever free it.

With a non-default `stt_model_ttl` of `-1` the memory is never reclaimed at all, short of restarting the server.

### Reproduction

Send a transcription and, while it is still running, ask for the model to be unloaded:

```
POST /api/ps/Systran/faster-whisper-large-v3    # load
POST /v1/audio/transcriptions                   # long file, still running
DELETE /api/ps/Systran/faster-whisper-large-v3  # -> 409 "still in use"
GET  /api/ps                                    # -> [] , but the weights are still on the card
DELETE /api/ps/Systran/faster-whisper-large-v3  # -> 404, forever
```

`tests/base_model_manager_test.py::test_unload_model_keeps_the_entry_when_the_model_is_in_use` in this PR is the same sequence without the HTTP layer or a model download; it fails on `master` with `assert 'm' in OrderedDict()` and passes with the change.

We hit this from an orchestrator that unloads idle models to free VRAM for another workload. It asked once, got a `409`, and from that point had no way to see or retry the 2.1 GB it was still being charged for.

### The change

Do not remove the entry in `unload_model`. `unload()` already calls `model_unloaded_callback` → `_handle_model_unloaded`, which removes it, and that is the same path the expire timer takes. The entry now disappears only once the weights actually have, and a refused unload stays listed and addressable for a retry.

`self._lock` is released before `unload()` runs (unchanged), so the callback re-acquiring it cannot deadlock.

Behaviour that is deliberately unchanged: a successful unload still removes the entry, and an unknown model still raises `KeyError` → `404`.

### Tests

Adds `tests/base_model_manager_test.py` — three unit tests against `BaseModelManager` directly, no model download and no HTTP client, so they run in under a tenth of a second. On `master` the in-use test fails and the other two pass; with the change all three pass.

### Note on a related, separate issue

Context, not a claim to fix it. While reproducing this I read #213, which reports that `faster-whisper` returns a lazy generator, so `ref_count` can reach 0 while segments are still being produced. If that is right, `ref_count > 0` under-reports "in use", which means a refused unload is not the only route by which weights can outlive their registry entry. That makes the ordering here worth getting right regardless of #213, since the registry entry is what any caller has to work with. #213 itself is a separate defect and this PR does not touch it.
